### PR TITLE
 README: fix typo in nix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ note: you would only do this if you're on the actual specific machine that you'r
 ```sh
 nix-shell -p git --run 'git clone https://github.com/Francesco149/flake ~/flake'
 cd ~/flake
-ix-shell -p git --run 'nix --extra-experimental-features nix-command --extra-experimental-features flakes develop' # or nix-shell
+nix-shell -p git --run 'nix --extra-experimental-features nix-command --extra-experimental-features flakes develop' # or nix-shell
 nixos-rebuild switch --use-remote-sudo --flake .#tanuki
 
 # relog into your user or reboot


### PR DESCRIPTION
oops~  there's a typo in `README.md` where `ix-shell` should be `nix-shell`

# Unlicensing your contributions
- [x] If this is a non-trivial contribution (more than 15 lines of code changed), I will attach a contributor waiver as explained in
      [the contributor guidelines](../blob/master/CONTRIBUTING.md) .
